### PR TITLE
[FIX] avoid comparison of None with int for empty queries

### DIFF
--- a/prf/es.py
+++ b/prf/es.py
@@ -744,7 +744,7 @@ class ES(object):
 
         def check_pagination_limit():
             pagination_limit = self.settings.asint('max_result_window', default=MAX_RESULT_WINDOW)
-            if specials._start > pagination_limit:
+            if (specials._start or 0) > pagination_limit:
                 raise prf.exc.HTTPBadRequest('Reached max pagination limit of `%s`' % pagination_limit)
 
         _s = self.build_search_object(_params, specials)


### PR DESCRIPTION
This raises an error in situations when the result of a query is null, and then tries to compare a None object with 0 (which is int) - and it results in a server-side error.
I have added an **or** operator to convert a None object to 0 to avoid this error.